### PR TITLE
Reevaluate skip conditions on "mergeable?" checks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -911,12 +911,7 @@ async function merge(context, pullRequest) {
     }
   } = context;
 
-  const ready = await waitUntilReady(
-    octokit,
-    pullRequest,
-    mergeRetries,
-    mergeRetrySleep
-  );
+  const ready = await waitUntilReady(pullRequest, context);
   if (!ready) {
     return false;
   }
@@ -1090,20 +1085,32 @@ function skipPullRequest(context, pullRequest) {
   return skip;
 }
 
-function waitUntilReady(octokit, pullRequest, mergeRetries, mergeRetrySleep) {
+function waitUntilReady(pullRequest, context) {
+  const {
+    octokit,
+    config: { mergeRetries, mergeRetrySleep }
+  } = context;
+
   return retry(
     mergeRetries,
     mergeRetrySleep,
-    () => checkReady(pullRequest),
+    () => checkReady(pullRequest, context),
     async () => {
       const pr = await getPullRequest(octokit, pullRequest);
-      return checkReady(pr);
+      return checkReady(pr, context);
     },
     () => logger.info(`PR not ready to be merged after ${mergeRetries} tries`)
   );
 }
 
-function checkReady(pullRequest) {
+function checkReady(pullRequest, context) {
+  if (skipPullRequest(context, pullRequest)) {
+    return "failure";
+  }
+  return mergeable(pullRequest);
+}
+
+function mergeable(pullRequest) {
   const { mergeable_state } = pullRequest;
   if (mergeable_state == null || MAYBE_READY.includes(mergeable_state)) {
     logger.info("PR is probably ready: mergeable_state:", mergeable_state);
@@ -18039,7 +18046,7 @@ module.exports = eval("require")("encoding");
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"automerge-action","version":"0.13.0","description":"GitHub action to automatically merge pull requests","main":"lib/api.js","author":"Pascal","license":"MIT","private":true,"bin":{"automerge-action":"./bin/automerge.js"},"scripts":{"test":"jest","it":"node it/it.js","lint":"prettier -l lib/** test/** && eslint .","compile":"ncc build bin/automerge.js --license LICENSE -o dist","prepublish":"yarn lint && yarn test && yarn compile"},"dependencies":{"@octokit/rest":"^18.5.3","argparse":"^2.0.1","fs-extra":"^10.0.0","object-resolve-path":"^1.1.1","tmp":"^0.2.1"},"devDependencies":{"@vercel/ncc":"^0.28.6","dotenv":"^10.0.0","eslint":"^7.27.0","eslint-plugin-jest":"^24.3.6","jest":"^27.0.1","prettier":"^2.3.0"},"prettier":{"trailingComma":"none","arrowParens":"avoid"}}');
+module.exports = JSON.parse('{"name":"automerge-action","version":"0.13.0","description":"GitHub action to automatically merge pull requests","main":"lib/api.js","author":"Pascal","license":"MIT","private":true,"bin":{"automerge-action":"./bin/automerge.js"},"scripts":{"test":"jest","it":"node it/it.js","lint":"prettier -lw lib/** test/** && eslint .","compile":"ncc build bin/automerge.js --license LICENSE -o dist","prepublish":"yarn lint && yarn test && yarn compile"},"dependencies":{"@octokit/rest":"^18.5.3","argparse":"^2.0.1","fs-extra":"^10.0.0","object-resolve-path":"^1.1.1","tmp":"^0.2.1"},"devDependencies":{"@vercel/ncc":"^0.28.6","dotenv":"^10.0.0","eslint":"^7.27.0","eslint-plugin-jest":"^24.3.6","jest":"^27.0.1","prettier":"^2.3.0"},"prettier":{"trailingComma":"none","arrowParens":"avoid"}}');
 
 /***/ }),
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -32,12 +32,7 @@ async function merge(context, pullRequest) {
     }
   } = context;
 
-  const ready = await waitUntilReady(
-    octokit,
-    pullRequest,
-    mergeRetries,
-    mergeRetrySleep
-  );
+  const ready = await waitUntilReady(pullRequest, context);
   if (!ready) {
     return false;
   }
@@ -211,20 +206,32 @@ function skipPullRequest(context, pullRequest) {
   return skip;
 }
 
-function waitUntilReady(octokit, pullRequest, mergeRetries, mergeRetrySleep) {
+function waitUntilReady(pullRequest, context) {
+  const {
+    octokit,
+    config: { mergeRetries, mergeRetrySleep }
+  } = context;
+
   return retry(
     mergeRetries,
     mergeRetrySleep,
-    () => checkReady(pullRequest),
+    () => checkReady(pullRequest, context),
     async () => {
       const pr = await getPullRequest(octokit, pullRequest);
-      return checkReady(pr);
+      return checkReady(pr, context);
     },
     () => logger.info(`PR not ready to be merged after ${mergeRetries} tries`)
   );
 }
 
-function checkReady(pullRequest) {
+function checkReady(pullRequest, context) {
+  if (skipPullRequest(context, pullRequest)) {
+    return "failure";
+  }
+  return mergeable(pullRequest);
+}
+
+function mergeable(pullRequest) {
   const { mergeable_state } = pullRequest;
   if (mergeable_state == null || MAYBE_READY.includes(mergeable_state)) {
     logger.info("PR is probably ready: mergeable_state:", mergeable_state);


### PR DESCRIPTION
> **AUTHOR'S NOTE**
> cc @Zen8 @mattmanske @spencersamuel7 @pevner-p2 @rhymiz @kylemcc 
> I took another look at this problem, and decided the fix was super simple. So I forked the `automerge` action so I could fix it for us. I think we should consider submitting this as a PR against the original after we've verified its value to us, so that we don't have to maintain this fork. That said, I would not expect this to need changing much, or ever, so the maintenance cost is pretty low.

When `automerge` is triggered, it first asks a bunch of questions to determine if it should even bother trying to merge. If those checks pass, it starts polling the Github API to determine if the PR is "mergeable".

After the initial run through of what I'll call the "skip factors", it never looks at them again. This is undesirable and problematic for a number of reasons, but particularly for long-running configurations (i.e. automerges configured to wait several minutes or even hours before giving up). In particular:
- If a required PR label is added or removed after the `automerge` job initially starts, it won't know, and may merge the PR when it shouldn't.
- If the PR is closed after the `automerge` job initially starts, it won't know, and may merge the PR after it has been closed (a totally valid action if the head of the branch is "mergeable," just not an available action through the Github UI).

We have observed several instances where the `automerge` action is triggered when a pull request is created, but the PR is not immediately mergeable and so it begins its polling; only to miss the addition of labels that should block the merge, or even worse, to miss the closure of the PR itself. There was one incident where the PR was merged a full 30min after it was closed!

This PR addresses the problem by adding the "should automerge be skipped?" check to the "can this PR be automerged?" polling mechanism. This simple fix resolves the observed issues without any noticeable latency overhead.



## How to test
I have created a test repository for integration testing this action: https://github.com/ProdPerfect/brady-test

It comes equipped with a CircleCI integration that simply `sleeps` for 60 seconds, and a branch protection rule which requires this CircleCI job to pass before allowing commits to be merged into `main`. It also has a Github workflow configured to use this particular branch of our fork of the `automerge` action, with a modified version of our [production config](https://github.com/ProdPerfect/tfm-customer-suite/blob/f49967520545f7c4e89fa1941f92f3845545b09d/modules/testsuite/templates/automerge.yml#L1).

To iterate and test this action, simply create a PR against the `main` branch of that repo with a dummy commit. Without doing anything else, you will expect to see the CircleCI build trigger when the commit is pushed to the remote, and the `automerge` Github workflow trigger when the PR opens. After roughly 1 minute, CircleCI should finish, and `automerge` will merge your PR.

### Test scenario: `automerge` canceled when `needs review` label is attached to PR
To confirm that this PR addresses this scenario, first create a commit that points the `automerge` workflow to the official `automerge` Github action we currently use: `pascalgn/automerge-action@v0.12.08`

Then open a PR, and wait about 20-30 seconds for the `automerge` action to be triggered and start polling the PR for mergeability. Add the `needs review` label after confirming `automerge` has started running: you should expect it to have no effect, and that the PR is automerged when the CircleCI build passes.

That's the baseline. Now, remove that change to the workflow, pointing it back at this branch of the action, and do the same thing. This time, you should expect to see the `automerge` check finish successfully and gracefully soon after you add the label, without actually merging your PR. Now, remove the label; the `automerge` action should trigger again, and this time it should merge your PR as soon as CircleCI finishes successfully.

### Test scenario: `automerge` canceled on PR closure
To confirm that this PR addresses this scenario, first create a commit that points the `automerge` workflow to the official `automerge` Github action we currently use: `pascalgn/automerge-action@v0.12.08`

Then open a PR, and wait about 20-30 seconds for the `automerge` action to be triggered and start polling the PR for mergeability. At this point, close the PR, ensuring you do so before the CircleCI build finishes, but after the `automerge` job has started. Remain on the PR page: you should observe the PR go from "closed" to "merged" within a few seconds, when CircleCI finishes and the still-running `automerge` job does its thing.

That's the baseline. Now, remove that change to the workflow, pointing it back at this branch of the action, and do the same thing. This time, you should expect to see the `automerge` check finish successfully and gracefully soon after you close the PR, without actually merging your PR; you can view this in the "Checks" tab of the PR (closing the PR takes away the convenient link on the main PR page).